### PR TITLE
Fix run_CMU when running with the flag --from_poses

### DIFF
--- a/pixloc/localization/localizer.py
+++ b/pixloc/localization/localizer.py
@@ -142,7 +142,7 @@ class PoseLocalizer(Localizer):
             self.conf.refinement)
 
         logger.info('Reading hloc logs...')
-        with open(paths.log_path, 'rb') as f:
+        with open(paths.hloc_logs, 'rb') as f:
             self.logs = pickle.load(f)['loc']
 
     def run_query(self, name: str, camera: Camera):

--- a/pixloc/run_7Scenes.py
+++ b/pixloc/run_7Scenes.py
@@ -36,7 +36,7 @@ default_confs = {
             'do_pose_approximation': False,
         },
     },
-    'from_pose': {
+    'from_poses': {
         'experiment': experiment,
         'features': {},
         'optimizer': {

--- a/pixloc/run_Aachen.py
+++ b/pixloc/run_Aachen.py
@@ -35,7 +35,7 @@ default_confs = {
             'do_pose_approximation': True,
         },
     },
-    'from_pose': {
+    'from_poses': {
         'experiment': experiment,
         'features': {'preprocessing': {'resize': 1600}},
         'optimizer': {

--- a/pixloc/run_CMU.py
+++ b/pixloc/run_CMU.py
@@ -13,7 +13,7 @@ default_paths = Paths(
     query_list='slice{slice}/queries_with_intrinsics.txt',
     global_descriptors='slice{slice}/cmu-slice{slice}_tf-netvlad.h5',
     retrieval_pairs='slice{slice}/pairs-query-netvlad10.txt',
-    log_path='slice{slice}/CMU_hloc_superpoint+superglue_netvlad10.txt_logs.pkl',
+    hloc_logs='slice{slice}/CMU_hloc_superpoint+superglue_netvlad10.txt_logs.pkl',
     results='pixloc_CMU_slice{slice}.txt',
 )
 

--- a/pixloc/run_CMU.py
+++ b/pixloc/run_CMU.py
@@ -35,7 +35,7 @@ default_confs = {
             'do_pose_approximation': False,
         },
     },
-    'from_pose': {
+    'from_poses': {
         'experiment': experiment,
         'features': {},
         'optimizer': {

--- a/pixloc/run_CMU.py
+++ b/pixloc/run_CMU.py
@@ -13,6 +13,7 @@ default_paths = Paths(
     query_list='slice{slice}/queries_with_intrinsics.txt',
     global_descriptors='slice{slice}/cmu-slice{slice}_tf-netvlad.h5',
     retrieval_pairs='slice{slice}/pairs-query-netvlad10.txt',
+    log_path='slice{slice}/CMU_hloc_superpoint+superglue_netvlad10.txt_logs.pkl',
     results='pixloc_CMU_slice{slice}.txt',
 )
 

--- a/pixloc/run_Cambridge.py
+++ b/pixloc/run_Cambridge.py
@@ -36,7 +36,7 @@ default_confs = {
             'do_pose_approximation': False,
         },
     },
-    'from_pose': {
+    'from_poses': {
         'experiment': experiment,
         'features': {},
         'optimizer': {

--- a/pixloc/run_RobotCar.py
+++ b/pixloc/run_RobotCar.py
@@ -35,7 +35,7 @@ default_confs = {
             'do_pose_approximation': False,
         },
     },
-    'from_pose': {
+    'from_poses': {
         'experiment': experiment,
         'features': {},
         'optimizer': {

--- a/pixloc/utils/data.py
+++ b/pixloc/utils/data.py
@@ -21,6 +21,7 @@ class Paths:
     results: Optional[Path] = None
     global_descriptors: Optional[Path] = None
     hloc_logs: Optional[Path] = None
+    log_path: Optional[Path] = None
     ground_truth: Optional[Path] = None
 
     def interpolate(self, **kwargs) -> 'Paths':

--- a/pixloc/utils/data.py
+++ b/pixloc/utils/data.py
@@ -21,7 +21,6 @@ class Paths:
     results: Optional[Path] = None
     global_descriptors: Optional[Path] = None
     hloc_logs: Optional[Path] = None
-    log_path: Optional[Path] = None
     ground_truth: Optional[Path] = None
 
     def interpolate(self, **kwargs) -> 'Paths':


### PR DESCRIPTION
This PR relates to #23, which faces a similar issue on the Aachen dataset.

The fix adds a field `log_path` to the `Path` class and populates the corresponding setup for the run_CMU.py file.

I've initiated a test locally using `python3 -m pixloc.run_CMU --from_poses --slices 3` (for brevity). The evaluation is running as expected, and I will report back the final results.