### PR TITLE
Replace parse_intermixed_args by parse_args

### DIFF
--- a/pixloc/pixlib/train.py
+++ b/pixloc/pixlib/train.py
@@ -365,7 +365,7 @@ if __name__ == '__main__':
     parser.add_argument('--restore', action='store_true')
     parser.add_argument('--distributed', action='store_true')
     parser.add_argument('dotlist', nargs='*')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
 
     logger.info(f'Starting experiment {args.experiment}')
     output_dir = Path(TRAINING_PATH, args.experiment)

--- a/pixloc/run_7Scenes.py
+++ b/pixloc/run_7Scenes.py
@@ -62,7 +62,7 @@ def main():
     parser = create_argparser('7Scenes')
     parser.add_argument('--scenes', default=SCENES, choices=SCENES, nargs='+')
     parser.add_argument('--eval_only', action='store_true')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
 
     set_logging_debug(args.verbose)
     paths = parse_paths(args, default_paths)

--- a/pixloc/run_Aachen.py
+++ b/pixloc/run_Aachen.py
@@ -56,7 +56,7 @@ default_confs = {
 
 def main():
     parser = create_argparser('Aachen')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
     set_logging_debug(args.verbose)
     paths = parse_paths(args, default_paths)
     conf = parse_conf(args, default_confs)

--- a/pixloc/run_CMU.py
+++ b/pixloc/run_CMU.py
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('--slices', type=str,
                         help='a single number, an interval (e.g. 2-6), '
                         'or a Python-style list or int (e.g. [2, 3, 4]')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
 
     set_logging_debug(args.verbose)
     paths = parse_paths(args, default_paths)

--- a/pixloc/run_Cambridge.py
+++ b/pixloc/run_Cambridge.py
@@ -62,7 +62,7 @@ def main():
     parser = create_argparser('Cambridge')
     parser.add_argument('--scenes', default=SCENES, choices=SCENES, nargs='+')
     parser.add_argument('--eval_only', action='store_true')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
 
     set_logging_debug(args.verbose)
     paths = parse_paths(args, default_paths)

--- a/pixloc/run_RobotCar.py
+++ b/pixloc/run_RobotCar.py
@@ -84,7 +84,7 @@ def main():
     parser = create_argparser('RobotCar')
     parser.add_argument('--conditions', default=CONDITIONS, choices=CONDITIONS,
                         nargs='+')
-    args = parser.parse_intermixed_args()
+    args = parser.parse_args()
 
     set_logging_debug(args.verbose)
     paths = parse_paths(args, default_paths)


### PR DESCRIPTION
`ArgumentParser.parse_intermixed_args` was introduced in Python 3.7